### PR TITLE
Fix/11

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install minikube
-        uses: opsgang/ga-setup-minikube@v0.1.1
+        uses: opsgang/ga-setup-minikube@6e4da5e0864402dd8748812cf0bc5c1f46cd05b5
         with:
           minikube-version: 1.7.2
           k8s-version: 1.17.2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install minikube
-        uses: unfor19/ga-setup-minikube@0539662fc6d9300f25498c2a2f80086ff283d29e
+        uses: unfor19/ga-setup-minikube@24fa7fa7154668b03cc371c59a467c3282bdb07b
         with:
           minikube-version: 1.7.2
           k8s-version: 1.17.2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install minikube
-        uses: opsgang/ga-setup-minikube@6e4da5e0864402dd8748812cf0bc5c1f46cd05b5
+        uses: unfor19/ga-setup-minikube@0539662fc6d9300f25498c2a2f80086ff283d29e
         with:
           minikube-version: 1.7.2
           k8s-version: 1.17.2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install minikube
-        uses: unfor19/ga-setup-minikube@24fa7fa7154668b03cc371c59a467c3282bdb07b
+        uses: unfor19/ga-setup-minikube@ca5bb1bd1ae316f95a86f882b9eb9ae866b8ab9e
         with:
           minikube-version: 1.7.2
           k8s-version: 1.17.2

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ $ pip install frigga
 ### Getting Started
 
 1. git clone this repository
+1. Run Docker daemon (Docker for Desktop)
+1. Make sure port 8080 is not in use
 1. Deploy locally the services: Prometheus, Grafana, node-exporter and cadvisor
 
    ```bash
@@ -138,6 +140,7 @@ $ pip install frigga
 1. Get all the metrics that are used in your Grafana dasboards
 
    ```bash
+   $ export GRAFANA_API_KEY=the-key-that-was-generated-in-the-deploy-locally-step
    $ frigga gl -gurl http://localhost:3000 -gkey $GRAFANA_API_KEY
 
    >> [LOG] Getting the list of words to ignore when scraping from Grafana

--- a/docker-compose/deploy_stack.sh
+++ b/docker-compose/deploy_stack.sh
@@ -8,7 +8,9 @@ generate_apikey(){
         --data '{"name":"local","role":"Viewer","secondsToLive":86400}' \
         http://localhost:3000/api/auth/keys | jq -r .key)
     echo $apikey
-    [[ ! -z $FRIGGA_TESTING ]] && echo $apikey > .apikey
+    echo $apikey > .apikey && echo ">> API Key was saved in .apikey file"
+    echo ">> Export the key as environment variable for later use"
+    echo "export GRAFANA_API_KEY=${apikey}"
 }
 
 grafana_update_admin_password(){

--- a/scripts/grafana.py
+++ b/scripts/grafana.py
@@ -78,7 +78,7 @@ def get_metrics_list(base_url, api_key):
         base_url
     ).json()
     data = {
-        "dashboards": {}
+        "dashboards": dict()
     }
     for dashboard in dashboards:
         dashboard_body = grafana_http_request(
@@ -91,8 +91,9 @@ def get_metrics_list(base_url, api_key):
         dashboard_name = dashboard_body['meta']['slug'] if 'slug' in dashboard_body[
             'meta'] and dashboard_body['meta']['slug'] else "null"
         print_msg(msg_content=f"Getting metrics from {dashboard_name}")
-        expressions = scrape_value_by_key(dashboard_body, "expr", str)
-        expressions += scrape_value_by_key(dashboard_body, "query", str)
+        expressions = \
+            scrape_value_by_key(dashboard_body, "expr", str, []) \
+            + scrape_value_by_key(dashboard_body, "query", str, [])
         dashboard_metrics = []
         for expression in expressions:
             try:


### PR DESCRIPTION
Closes #11 

The problem was in - 

```python
        expressions = \
            scrape_value_by_key(dashboard_body, "expr", str, []) \
            + scrape_value_by_key(dashboard_body, "query", str, [])
```

Previously, the function `scrape_value_by_key` used the default `my_list=[]`, which caused a fixed reference to the same Python object `list`. Passing an empty list `[]` to this function sets the relevant expressions per dashboard.

