### PR TITLE
Feature/prometheus rules file

### DIFF
--- a/scripts/frigga.py
+++ b/scripts/frigga.py
@@ -56,7 +56,7 @@ def cli(config, ci):
 @click.option('--output-file-path', '-o', default='./.metrics.json', show_default=True, required=False, type=str)
 # @click.option('--file', '-f', prompt=False, default=".", help="Output metrics.json file to pwd")
 def grafana_list(grafana_url, grafana_api_key, output_file_path):
-    """Provide Grafana UrL and Grafana API Key (Viewer)\n
+    """Provide Grafana URL and Grafana API Key (Viewer)\n
 Returns a list of metrics that are used in all dashboards"""
     if "http" not in grafana_url:
         print_msg(
@@ -70,7 +70,7 @@ Returns a list of metrics that are used in all dashboards"""
 @click.option('--prom-yaml-path', '-ppath', default='docker-compose/prometheus.yml', prompt=True, required=True, show_default=False, type=str)
 @click.option('--metrics-json-path', '-mjpath', default='./.metrics.json', show_default=True, prompt=True, required=False, type=str)
 @click.option('--create-backup-file', '-b', is_flag=True, default=True, required=False)
-@click.option('--skip-rules-file', '-b', is_flag=True, default=False, required=False)
+@click.option('--skip-rules-file', '-sr', is_flag=True, default=False, required=False)
 def prometheus_apply(prom_yaml_path, metrics_json_path, create_backup_file, skip_rules_file):
     apply_yaml(prom_yaml_path, metrics_json_path,
                create_backup_file, skip_rules_file)

--- a/scripts/frigga.py
+++ b/scripts/frigga.py
@@ -56,7 +56,8 @@ def cli(config, ci):
 @click.option('--output-file-path', '-o', default='./.metrics.json', show_default=True, required=False, type=str)
 # @click.option('--file', '-f', prompt=False, default=".", help="Output metrics.json file to pwd")
 def grafana_list(grafana_url, grafana_api_key, output_file_path):
-    """Provide Grafana URL and Grafana API Key (Viewer)\n
+    """Alias: gl\n
+Provide Grafana URL and Grafana API Key (Viewer)\n
 Returns a list of metrics that are used in all dashboards"""
     if "http" not in grafana_url:
         print_msg(
@@ -72,5 +73,11 @@ Returns a list of metrics that are used in all dashboards"""
 @click.option('--create-backup-file', '-b', is_flag=True, default=True, required=False)
 @click.option('--skip-rules-file', '-sr', is_flag=True, default=False, required=False)
 def prometheus_apply(prom_yaml_path, metrics_json_path, create_backup_file, skip_rules_file):
+    """Alias: pa\n
+Applies .metrics.json for a given prometheus.yml file\n
+By default:\n
+- Creates a backup of prometheus.yml to prometheus.yml.bak.yml (same dir as prometheus.yml)\n
+- Creates a .prometheus-rules.yml file with all relabel_configs
+    """
     apply_yaml(prom_yaml_path, metrics_json_path,
                create_backup_file, skip_rules_file)

--- a/scripts/frigga.py
+++ b/scripts/frigga.py
@@ -70,5 +70,7 @@ Returns a list of metrics that are used in all dashboards"""
 @click.option('--prom-yaml-path', '-ppath', default='docker-compose/prometheus.yml', prompt=True, required=True, show_default=False, type=str)
 @click.option('--metrics-json-path', '-mjpath', default='./.metrics.json', show_default=True, prompt=True, required=False, type=str)
 @click.option('--create-backup-file', '-b', is_flag=True, default=True, required=False)
-def prometheus_apply(prom_yaml_path, metrics_json_path, create_backup_file):
-    apply_yaml(prom_yaml_path, metrics_json_path, create_backup_file)
+@click.option('--skip-rules-file', '-b', is_flag=True, default=False, required=False)
+def prometheus_apply(prom_yaml_path, metrics_json_path, create_backup_file, skip_rules_file):
+    apply_yaml(prom_yaml_path, metrics_json_path,
+               create_backup_file, skip_rules_file)

--- a/scripts/prometheus.py
+++ b/scripts/prometheus.py
@@ -42,7 +42,7 @@ def get_ignored_words():
     return sorted(list(set(words_list)))
 
 
-def apply_yaml(prom_yaml_path, metrics_json_path, create_backup_file=True):
+def apply_yaml(prom_yaml_path, metrics_json_path, create_backup_file=True, skip_rules_file=False):
     print_msg(msg_content=f"Reading documents from {prom_yaml_path}")
     with open(prom_yaml_path, "r") as file:
         prom_yaml = file.read()
@@ -79,12 +79,27 @@ def apply_yaml(prom_yaml_path, metrics_json_path, create_backup_file=True):
         "regex": True,
         "action": "keep"
     })
-    for job in prom_doc['scrape_configs']:
-        if job['job_name'] not in frigga_doc['exclude_jobs']:
-            job['metric_relabel_configs'] = metric_relabel_configs
 
     noalias_dumper = yaml.dumper.SafeDumper
     noalias_dumper.ignore_aliases = lambda self, data: True
+
+    # write relabel configs to file
+    if not skip_rules_file:
+        rules_file_path = ".prometheus-rules.yml"
+        print_msg(
+            msg_content=f"Writing the relabel_configs to {rules_file_path}")
+        with open(rules_file_path, 'w') as fs:
+            data = yaml.dump_all(
+                documents=[metric_relabel_configs],
+                stream=fs, default_flow_style=False,
+                Dumper=noalias_dumper,
+                indent=2
+            )
+
+    # add relabel configs to all jobs, except the ones in exclude_jobs
+    for job in prom_doc['scrape_configs']:
+        if job['job_name'] not in frigga_doc['exclude_jobs']:
+            job['metric_relabel_configs'] = metric_relabel_configs
 
     # backup old prom yaml
     if create_backup_file:


### PR DESCRIPTION
- [ENHANCEMENT] By default, the command `frigga prometheus-apply` (or `frigga pa`) creates a `.prometheus-rules.yml` file. This file contains `relabel_configs`, which makes it easier to copy-paste if necessary.<br>Can be skipped by adding the flag `--skip-rules-file`